### PR TITLE
Add `/` to prevent InvalidAuthenticityToken error

### DIFF
--- a/sample/app/views/home/show.html.erb
+++ b/sample/app/views/home/show.html.erb
@@ -1,5 +1,5 @@
 <section class="jumbotron text-center">
   <h2><img class="jumbo-thumbnail" src="https://cdn.auth0.com/styleguide/1.0.0/img/badge.svg"></h2>
   <h1>RoR Auth0 Sample</h1>
-  <%= button_to 'Login', 'auth/auth0', method: :post, class: 'btn btn-success btn-lg', id: 'qsLoginBtn' unless session[:userinfo].present? %>
+  <%= button_to 'Login', '/auth/auth0', method: :post, class: 'btn btn-success btn-lg', id: 'qsLoginBtn' unless session[:userinfo].present? %>
 </section>


### PR DESCRIPTION
The current example results in an InvalidAuthenticityToken error when used without a preceding slash. The issue appears to be fixed when a slash is added.

The following error logs are thrown when the button is set without a preceding `/`:
ie. `<%= button_to 'Login', 'auth/auth0', { method: :post } %>`
Logs:
```
Started POST "/auth/auth0" for 127.0.0.1 at 2021-07-13 17:18:25 -0400
D, [2021-07-13T17:18:25.221546 #20667] DEBUG -- omniauth: (auth0) Request phase initiated.
E, [2021-07-13T17:18:25.222133 #20667] ERROR -- omniauth: (auth0) Authentication failure! ActionController::InvalidAuthenticityToken: ActionController::InvalidAuthenticityToken, ActionController::InvalidAuthenticityToken
  
ActionController::InvalidAuthenticityToken (ActionController::InvalidAuthenticityToken):
  
omniauth-rails_csrf_protection (1.0.0) lib/omniauth/rails_csrf_protection/token_verifier.rb:34:in `call'
omniauth (2.0.4) lib/omniauth/strategy.rb:240:in `request_call'
omniauth (2.0.4) lib/omniauth/strategy.rb:193:in `call!'
omniauth (2.0.4) lib/omniauth/strategy.rb:169:in `call'
omniauth (2.0.4) lib/omniauth/builder.rb:45:in `call'
```
Reference: https://github.com/cookpad/omniauth-rails_csrf_protection/issues/8#issuecomment-659603672